### PR TITLE
fix: add copy_file_to_bin bazel-lib toolchain

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 )
 
 # Lower-bounds (minimum) versions for direct runtime dependencies
-bazel_dep(name = "aspect_bazel_lib", version = "1.30.2")
+bazel_dep(name = "aspect_bazel_lib", version = "1.38.0")
 bazel_dep(name = "aspect_rules_js", version = "1.29.2")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -1,6 +1,6 @@
 "Bazel dependencies"
 
-bazel_dep(name = "aspect_bazel_lib", version = "1.30.2", dev_dependency = True)
+bazel_dep(name = "aspect_bazel_lib", version = "1.38.0", dev_dependency = True)
 bazel_dep(name = "aspect_rules_terser", version = "0.0.0", dev_dependency = True)
 bazel_dep(name = "aspect_rules_js", version = "1.23.2", dev_dependency = True)
 

--- a/terser/defs.bzl
+++ b/terser/defs.bzl
@@ -7,6 +7,7 @@ load("//terser/private:terser.bzl", terser_lib = "lib")
 _terser = rule(
     implementation = terser_lib.implementation,
     attrs = terser_lib.attrs,
+    toolchains = terser_lib.toolchains,
 )
 
 def terser(

--- a/terser/dependencies.bzl
+++ b/terser/dependencies.bzl
@@ -11,9 +11,9 @@ def rules_terser_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "ee95bbc80f9ca219b93a8cc49fa19a2d4aa8649ddc9024f46abcdd33935753ca",
-        strip_prefix = "bazel-lib-1.29.2",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.29.2/bazel-lib-v1.29.2.tar.gz",
+        sha256 = "b848cd8e93be7f18c3deda6d2f3ade92a657d3585e119953bc50dc75fef535c2",
+        strip_prefix = "bazel-lib-1.38.0",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.38.0/bazel-lib-v1.38.0.tar.gz",
     )
 
     http_archive(

--- a/terser/private/terser.bzl
+++ b/terser/private/terser.bzl
@@ -1,6 +1,6 @@
 "terser"
 
-load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_files_to_bin_actions")
+load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "COPY_FILE_TO_BIN_TOOLCHAINS", "copy_files_to_bin_actions")
 load("@aspect_rules_js//js:libs.bzl", "js_lib_helpers")
 load("@aspect_rules_js//js:providers.bzl", "js_info")
 
@@ -151,4 +151,5 @@ def _impl(ctx):
 lib = struct(
     attrs = _ATTRS,
     implementation = _impl,
+    toolchains = COPY_FILE_TO_BIN_TOOLCHAINS,
 )


### PR DESCRIPTION
Pre-factor from https://github.com/aspect-build/rules_terser/pull/86

COPY_FILE_TO_BIN_TOOLCHAINS will be required in bazel-lib 2.x. This pre-factors that change which is compatible with a minimum bazel-lib of 1.38.0.