### PR TITLE
chore: bump minimum rules_nodejs to 6.2.0

### DIFF
--- a/terser/dependencies.bzl
+++ b/terser/dependencies.bzl
@@ -26,7 +26,7 @@ def rules_terser_dependencies():
 
     http_archive(
         name = "rules_nodejs",
-        sha256 = "dddd60acc3f2f30359bef502c9d788f67e33814b0ddd99aa27c5a15eb7a41b8c",
-        strip_prefix = "rules_nodejs-6.1.0",
-        url = "https://github.com/bazelbuild/rules_nodejs/releases/download/v6.1.0/rules_nodejs-v6.1.0.tar.gz",
+        sha256 = "87c6171c5be7b69538d4695d9ded29ae2626c5ed76a9adeedce37b63c73bef67",
+        strip_prefix = "rules_nodejs-6.2.0",
+        url = "https://github.com/bazelbuild/rules_nodejs/releases/download/v6.2.0/rules_nodejs-v6.2.0.tar.gz",
     )


### PR DESCRIPTION
Ensures users pick up https://github.com/bazelbuild/rules_nodejs/pull/3760 fix which is a footgun that should be avoided.