### PR TITLE
fix: silence warning from rosetta tracing during CCI yaml generation

### DIFF
--- a/.circleci/BUILD.bazel
+++ b/.circleci/BUILD.bazel
@@ -36,7 +36,7 @@ genrule(
     name = "aspect_workflows_config",
     srcs = ["//.aspect/workflows:config.yaml"],
     outs = [":aspect-workflows-config.yml"],
-    cmd = "CI=1 CIRCLE_PROJECT_USERNAME={0} $(execpath :rosetta) steps --configuration .aspect/workflows/config.yaml --host circleci > $@".format(CIRCLECI_ORG),
+    cmd = "CI=1 CIRCLE_PROJECT_USERNAME={0} ASPECT_WORKFLOWS_DISABLE_TRACES_COLLECTION=1 $(execpath :rosetta) steps --configuration .aspect/workflows/config.yaml --host circleci > $@".format(CIRCLECI_ORG),
     target_compatible_with = not_windows,
     tools = [":rosetta"],
 )


### PR DESCRIPTION
See https://github.com/aspect-build/silo/issues/6666 for more details