### PR TITLE
ci: do not test primary bazel version on github ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,11 @@ jobs:
           - os: windows
             bazel-version:
               major: 6
+          # Linux on the primary bazel version is tested on Aspect Workflows
+          - os: ubuntu
+            bazel-version:
+              major: 7
+            bzlmod: 1
     steps:
       - uses: actions/checkout@v4
       - name: Mount bazel caches


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
