### PR TITLE
Fix running terser from external repository.

### DIFF
--- a/terser/private/terser.bzl
+++ b/terser/private/terser.bzl
@@ -30,6 +30,11 @@ _ATTRS = {
 def _filter_js(files):
     return [f for f in files if f.is_directory or f.extension == "js" or f.extension == "mjs"]
 
+def maybe_prefix_external(path):
+  if path.startswith('../'):
+    return 'external' + path[2:]
+  return path
+
 def _impl(ctx):
     args = ctx.actions.args()
 
@@ -49,8 +54,8 @@ def _impl(ctx):
         if ctx.attr.sourcemap:
             output_sources.append(ctx.actions.declare_file("%s.js.map" % ctx.label.name))
 
-    args.add_all([s.short_path for s in input_sources])
-    args.add_all(["--output", output_sources[0].short_path])
+    args.add_all([maybe_prefix_external(s.short_path) for s in input_sources])
+    args.add_all(["--output", maybe_prefix_external(output_sources[0].short_path)])
 
     debug = ctx.attr.debug or ctx.var["COMPILATION_MODE"] == "dbg"
     if debug:
@@ -90,7 +95,7 @@ def _impl(ctx):
                 "\"bazel_no_debug\"": str(not debug).lower(),
             },
         )
-        args.add_all(["--config-file", options.short_path])
+        args.add_all(["--config-file", maybe_prefix_external(options.short_path)])
 
     ctx.actions.run(
         inputs = inputs,

--- a/terser/private/terser.bzl
+++ b/terser/private/terser.bzl
@@ -31,9 +31,9 @@ def _filter_js(files):
     return [f for f in files if f.is_directory or f.extension == "js" or f.extension == "mjs"]
 
 def maybe_prefix_external(path):
-  if path.startswith('../'):
-    return 'external' + path[2:]
-  return path
+    if path.startswith("../"):
+        return "external" + path[2:]
+    return path
 
 def _impl(ctx):
     args = ctx.actions.args()


### PR DESCRIPTION
I've got a repo which terses some typescript.  It works when built inside the repo, but when the exact same target is built outside the repo, it fails to build.

load("@aspect_rules_terser//terser:defs.bzl", terser_minified = "terser")

terser_minified(
    name = name + "__min",
    srcs = [":" + name],
    node_modules = "//:node_modules",
    sourcemap = False,
)

  (cd /dev/shm/bazel-sandbox.a3f391e631c5ea6c72bb0d2c0b90317c117ec497a3759d6de83cbe1ad7ada353/linux-sandbox/6993/execroot/spacecookies && \
  exec env - \
    BAZEL_BINDIR=bazel-out/k8-opt/bin \
    COMPILATION_MODE=opt \
    TMPDIR=/tmp \
  /home/austin/.cache/bazel/_bazel_austin/install/5309d864f9edb3a2e8380ffc84e6b95c/linux-sandbox -t 15 -w /dev/shm -w /dev/shm/bazel-sandbox.a3f391e631c5ea6c72bb0d2c0b90317c117ec497a3759d6de83cbe1ad7ada353/linux-sandbox/6993/execroot/spacecookies -w /tmp -e /tmp -S /dev/shm/bazel-sandbox.a3f391e631c5ea6c72bb0d2c0b90317c117ec497a3759d6de83cbe1ad7ada353/linux-sandbox/6993/stats.out -H -N -U -D /dev/shm/bazel-sandbox.a3f391e631c5ea6c72bb0d2c0b90317c117ec497a3759d6de83cbe1ad7ada353/linux-sandbox/6993/debug.out -- bazel-out/k8-opt-exec-ST-31ad040affd4/bin/external/aos/aos/network/www/_reflection_test_bundle__min_terser_binary_/_reflection_test_bundle__min_terser_binary ../aos/aos/network/www/reflection_test_bundle.js --output ../aos/aos/network/www/reflection_test_bundle__min.js --config-file bazel-out/k8-opt/bin/external/aos/aos/network/www/_reflection_test_bundle__min.minify_options.json)
node:internal/fs/utils:356
    throw err;
    ^

Error: ENOENT: no such file or directory, lstat '/dev/shm/bazel-sandbox.a3f391e631c5ea6c72bb0d2c0b90317c117ec497a3759d6de83cbe1ad7ada353/linux-sandbox/6993/execroot/spacecookies/bazel-out/k8-opt/aos/aos/network/www/reflection_test_bundle.js'
    at Object.lstatSync (node:fs:1666:3)
    at Object.lstatSync (/home/austin/.cache/bazel/_bazel_austin/0654a46dce625c9bc6e0b54d6df8dcff/external/aspect_rules_js/js/private/node-patches/fs.cjs:125:23)
    at isDirectory (/dev/shm/bazel-sandbox.a3f391e631c5ea6c72bb0d2c0b90317c117ec497a3759d6de83cbe1ad7ada353/linux-sandbox/6993/execroot/spacecookies/bazel-out/k8-opt-exec-ST-31ad040affd4/bin/external/aos/aos/network/www/_reflection_test_bundle__min_terser_binary_/_reflection_test_bundle__min_terser_binary.runfiles/aos/aos/network/www/_reflection_test_bundle__min_terser_runner.cjs:25:13)
    at Array.find (<anonymous>)
    at main (/dev/shm/bazel-sandbox.a3f391e631c5ea6c72bb0d2c0b90317c117ec497a3759d6de83cbe1ad7ada353/linux-sandbox/6993/execroot/spacecookies/bazel-out/k8-opt-exec-ST-31ad040affd4/bin/external/aos/aos/network/www/_reflection_test_bundle__min_terser_binary_/_reflection_test_bundle__min_terser_binary.runfiles/aos/aos/network/www/_reflection_test_bundle__min_terser_runner.cjs:251:15)
    at Object.<anonymous> (/dev/shm/bazel-sandbox.a3f391e631c5ea6c72bb0d2c0b90317c117ec497a3759d6de83cbe1ad7ada353/linux-sandbox/6993/execroot/spacecookies/bazel-out/k8-opt-exec-ST-31ad040affd4/bin/external/aos/aos/network/www/_reflection_test_bundle__min_terser_binary_/_reflection_test_bundle__min_terser_binary.runfiles/aos/aos/network/www/_reflection_test_bundle__min_terser_runner.cjs:269:3)
    at Module._compile (node:internal/modules/cjs/loader:1364:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
    at Module.load (node:internal/modules/cjs/loader:1203:32)
    at Module._load (node:internal/modules/cjs/loader:1019:12) {
  errno: -2,
  syscall: 'lstat',
  code: 'ENOENT',
  path: '/dev/shm/bazel-sandbox.a3f391e631c5ea6c72bb0d2c0b90317c117ec497a3759d6de83cbe1ad7ada353/linux-sandbox/6993/execroot/spacecookies/bazel-out/k8-opt/aos/aos/network/www/reflection_test_bundle.js'
}

Node.js v18.20.3

When built locally, instead of `../aos/aos/network/www/reflection_test_bundle.js`, it references `aos/network/www/reflection_test_bundle.js` which works. Manually adjusting it to `external/aos/aos/network/www/reflection_test_bundle.js` makes it build.  Really, this is an abuse of short_path, so abuse it a bit more.

<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
