### PR TITLE
ci: adopt aspect-build/setup-aspect

### DIFF
--- a/.github/workflows/ci-workflows.yaml
+++ b/.github/workflows/ci-workflows.yaml
@@ -7,9 +7,6 @@ on:
   workflow_dispatch:
 permissions:
   id-token: write
-env:
-  ASPECT_API_TOKEN: ${{ secrets.ASPECT_API_TOKEN }}
-  ASPECT_LAUNCHER_VERSION: 2026.22.39
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -18,70 +15,45 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
         with:
-          bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}-test-root
-          repository-cache: true
-          external-cache: true
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Test
-        run: |
-          curl -fsSL https://install.aspect.build | bash -s -- "$ASPECT_LAUNCHER_VERSION"
-          aspect test --task-key=test -- //...
+        run: aspect test --task-key=test -- //...
   format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
         with:
-          bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}-format-root
-          repository-cache: true
-          external-cache: true
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Format
-        run: |
-          curl -fsSL https://install.aspect.build | bash -s -- "$ASPECT_LAUNCHER_VERSION"
-          aspect format --task-key=format
+        run: aspect format --task-key=format
   buildifier:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
         with:
-          bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}-buildifier-root
-          repository-cache: true
-          external-cache: true
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Buildifier
-        run: |
-          curl -fsSL https://install.aspect.build | bash -s -- "$ASPECT_LAUNCHER_VERSION"
-          aspect buildifier --task-key=buildifier
+        run: aspect buildifier --task-key=buildifier
   test-e2e-smoke:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
         with:
-          bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}-test-e2e-smoke
-          repository-cache: true
-          external-cache: true
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Test (e2e/smoke)
         working-directory: e2e/smoke
-        run: |
-          curl -fsSL https://install.aspect.build | bash -s -- "$ASPECT_LAUNCHER_VERSION"
-          aspect test --task-key=test-e2e-smoke -- //...
+        run: aspect test --task-key=test-e2e-smoke -- //...
   gazelle:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
+      - uses: aspect-build/setup-aspect@c22a8f64fb38f82f59ce809cd7eb9f8ae096da44 # v2026.23.2
         with:
-          bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}-gazelle-root
-          repository-cache: true
-          external-cache: true
+          aspect-api-token: ${{ secrets.ASPECT_API_TOKEN }}
       - name: Gazelle
-        run: |
-          curl -fsSL https://install.aspect.build | bash -s -- "$ASPECT_LAUNCHER_VERSION"
-          aspect gazelle --task-key=gazelle
+        run: aspect gazelle --task-key=gazelle


### PR DESCRIPTION
Replace `bazel-contrib/setup-bazel` + manual `curl install.aspect.build` + top-level `ASPECT_API_TOKEN`/`ASPECT_LAUNCHER_VERSION` env vars with [`aspect-build/setup-aspect@v2026.23.2`](https://github.com/aspect-build/setup-aspect/releases/tag/v2026.23.2).

The action handles in one step:
- Launcher + Bazelisk install (no-op when `bazel` is already on PATH, e.g. Workflows runners)
- `bazelisk-cache` / `disk-cache` / `repository-cache` wiring on ephemeral runners
- `aspect auth login --with-api-token` to exchange the long-lived secret for a short-lived JWT — the raw token no longer leaks into every step's env

`ci-vanilla-bazel.yaml` is intentionally left alone.

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases