### PR TITLE
chore: remove WORKSPACE docs and release notes

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -9,7 +9,6 @@ TAG=$1
 PREFIX="rules_terser-${TAG:1}"
 ARCHIVE="rules_terser-$TAG.tar.gz"
 git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip >$ARCHIVE
-SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
 
 # Add generated API docs to the release, see https://github.com/bazelbuild/bazel-central-registry/issues/5593
 docs="$(mktemp -d)"
@@ -21,17 +20,8 @@ tar --create --auto-compress \
 	--file "$GITHUB_WORKSPACE/${ARCHIVE%.tar.gz}.docs.tar.gz" .
 
 cat <<EOF
-WORKSPACE snippet:
+\`MODULE.bazel\` snippet:
 \`\`\`starlark
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-http_archive(
-    name = "aspect_rules_terser",
-    sha256 = "${SHA}",
-    strip_prefix = "${PREFIX}",
-    url = "https://github.com/aspect-build/rules_terser/releases/download/${TAG}/${ARCHIVE}",
-)
+bazel_dep(name = "aspect_rules_terser", version = "${TAG:1}")
+\`\`\`
 EOF
-
-awk 'f;/--SNIP--/{f=1}' e2e/smoke/WORKSPACE.bazel
-
-echo "\`\`\`"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,20 +15,19 @@ Otherwise later tooling on CI may yell at you about formatting/linting violation
 
 ## Using this as a development dependency of other rules
 
-You'll commonly find that you develop in another WORKSPACE, such as
-some other ruleset that depends on rules_terser, or in a nested
-WORKSPACE in the integration_tests folder.
+You'll commonly find that you develop in another repository, such as
+some other ruleset that depends on rules_terser.
 
 To always tell Bazel to use this directory rather than some release
 artifact or a version fetched from the internet, run this from this
 directory:
 
 ```sh
-OVERRIDE="--override_repository=rules_terser=$(pwd)/rules_terser"
+OVERRIDE="--override_module=aspect_rules_terser=$(pwd)"
 echo "common $OVERRIDE" >> ~/.bazelrc
 ```
 
-This means that any usage of `@rules_terser` on your system will point to this folder.
+This means that any usage of `@aspect_rules_terser` on your system will point to this folder.
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,11 @@ _Need help?_ This ruleset has support provided by https://aspect.build/services.
 
 From the release you wish to use:
 <https://github.com/aspect-build/rules_terser/releases>
-copy the WORKSPACE snippet into your `WORKSPACE` file.
+copy the `MODULE.bazel` snippet into your `MODULE.bazel` file.
 
 ## Usage
 
 See the [API documentation](docs/rules) and the example usage in the [`examples/`](https://github.com/aspect-build/rules_terser/tree/main/examples/) directory.
-Note that the examples rely on code in the `/WORKSPACE` file in the root of this repo.
 
 ### From a BUILD file
 


### PR DESCRIPTION
### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
